### PR TITLE
ci: bump action pins to current

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: uv python install 3.14
       - run: |
           uv sync --all-extras --all-groups --frozen --no-install-project
@@ -43,8 +43,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: uv python install 3.14
       - run: |
           uv sync --all-extras --all-groups --frozen --no-install-project


### PR DESCRIPTION
## Summary

Bumps GitHub Actions in `main.yml`:

- `actions/checkout@v3` → `@v6`
- `astral-sh/setup-uv@v3` → `@v8.2.0`

Leaves `codecov/codecov-action@v4.0.1` untouched (separate decision; same scoping as the recent lite-bootstrap and modern-di-* alignment campaign).

## Test plan

- [ ] PR CI green (lint + pytest with postgres service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)