### PR TITLE
ci: drop codecov upload step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,3 @@ jobs:
           PYTHONDONTWRITEBYTECODE: 1
           PYTHONUNBUFFERED: 1
           DB_DSN: postgresql+asyncpg://postgres:password@127.0.0.1/postgres
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: ./coverage.xml
-          flags: unittests
-          name: codecov-${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Removes the `codecov/codecov-action@v4.0.1` upload step from `main.yml`. Coverage floor is already enforced by `--cov-fail-under=100` in `pyproject.toml`'s `[tool.pytest.ini_options]`, so codecov-action wasn't guarding anything that the test run doesn't already catch.

## Why now

The recent CI bump-pins PR (#22) surfaced a GitHub deprecation warning: `codecov-action@v4.0.1` runs on Node.js 20, which GitHub force-upgrades to Node.js 24 on 2026-06-16. Rather than carry that risk for a step that adds no enforcement, drop it.

## Operator follow-up

- The `CODECOV_TOKEN` repo secret is now unused. Can be deleted from Settings → Secrets and variables → Actions whenever convenient.

## Test plan

- [ ] PR CI green; pytest still fails the build below 100% coverage via the existing `--cov-fail-under=100` in `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)