### PR TITLE
refactor: collapse not-found handling into one seam

### DIFF
--- a/app/api/decks.py
+++ b/app/api/decks.py
@@ -1,9 +1,6 @@
 import typing
 
 import litestar
-from advanced_alchemy.exceptions import NotFoundError
-from litestar import status_codes
-from litestar.exceptions import HTTPException
 from litestar.params import FromPath  # noqa: TC002
 from litestar.plugins.pydantic import PydanticDTO
 
@@ -20,9 +17,6 @@ async def list_decks(decks_repository: DecksRepository) -> schemas.Decks:
 @litestar.get("/decks/{deck_id:int}/")
 async def get_deck(deck_id: FromPath[int], decks_repository: DecksRepository) -> schemas.Deck:
     instance = await decks_repository.fetch_with_cards(deck_id)
-    if not instance:
-        raise HTTPException(status_code=status_codes.HTTP_404_NOT_FOUND, detail="Deck is not found")
-
     return schemas.Deck.model_validate(instance)
 
 
@@ -32,10 +26,7 @@ async def update_deck(
     data: schemas.DeckCreate,
     decks_repository: DecksRepository,
 ) -> schemas.Deck:
-    try:
-        instance = await decks_repository.update(data=data.model_dump(), item_id=deck_id)
-    except NotFoundError:
-        raise HTTPException(status_code=status_codes.HTTP_404_NOT_FOUND, detail="Deck is not found") from None
+    instance = await decks_repository.update(data=data.model_dump(), item_id=deck_id)
     return schemas.Deck.model_validate(instance)
 
 
@@ -53,9 +44,7 @@ async def list_cards(deck_id: FromPath[int], cards_repository: CardsRepository) 
 
 @litestar.get("/cards/{card_id:int}/", return_dto=PydanticDTO[schemas.Card])
 async def get_card(card_id: FromPath[int], cards_repository: CardsRepository) -> schemas.Card:
-    instance = await cards_repository.get_one_or_none(models.Card.id == card_id)
-    if not instance:
-        raise HTTPException(status_code=status_codes.HTTP_404_NOT_FOUND, detail="Card is not found")
+    instance = await cards_repository.get_one(models.Card.id == card_id)
     return schemas.Card.model_validate(instance)
 
 

--- a/app/application.py
+++ b/app/application.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 import modern_di
 import modern_di_litestar
-from advanced_alchemy.exceptions import DuplicateKeyError
+from advanced_alchemy.exceptions import DuplicateKeyError, NotFoundError
 from lite_bootstrap import LitestarBootstrapper
 from litestar.config.app import AppConfig
 from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
@@ -25,6 +25,7 @@ def build_app() -> litestar.Litestar:
         application_config=AppConfig(
             exception_handlers={  # ty: ignore[invalid-argument-type]
                 DuplicateKeyError: exceptions.duplicate_key_error_handler,
+                NotFoundError: exceptions.not_found_error_handler,
             },
             route_handlers=[ROUTER],
             plugins=[modern_di_litestar.ModernDIPlugin(di_container)],

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -5,7 +5,7 @@ from litestar import status_codes
 
 
 if typing.TYPE_CHECKING:
-    from advanced_alchemy.exceptions import DuplicateKeyError
+    from advanced_alchemy.exceptions import DuplicateKeyError, NotFoundError
 
 
 def duplicate_key_error_handler(_: object, exc: DuplicateKeyError) -> litestar.Response[dict[str, typing.Any]]:
@@ -13,4 +13,12 @@ def duplicate_key_error_handler(_: object, exc: DuplicateKeyError) -> litestar.R
         media_type=litestar.MediaType.JSON,
         content={"detail": exc.detail},
         status_code=status_codes.HTTP_400_BAD_REQUEST,
+    )
+
+
+def not_found_error_handler(_: object, __: NotFoundError) -> litestar.Response[dict[str, typing.Any]]:
+    return litestar.Response(
+        media_type=litestar.MediaType.JSON,
+        content={"detail": "Not found"},
+        status_code=status_codes.HTTP_404_NOT_FOUND,
     )

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -17,8 +17,8 @@ class DecksRepository(SQLAlchemyAsyncRepositoryService[models.Deck]):
 
     repository_type = BaseRepository
 
-    async def fetch_with_cards(self, deck_id: int) -> models.Deck | None:
-        return await self.get_one_or_none(
+    async def fetch_with_cards(self, deck_id: int) -> models.Deck:
+        return await self.get_one(
             models.Deck.id == deck_id,
             load=[orm.selectinload(models.Deck.cards)],
         )


### PR DESCRIPTION
## What

Three handlers each re-derived the not-found → 404 policy, via **two different mechanisms**:

- `get_deck` / `get_card`: `get_one_or_none(...)` then `if not instance: raise HTTPException(404, ...)`
- `update_deck`: `try: ... except NotFoundError: raise HTTPException(404, ...)`

This consolidates that policy into **one seam**: a single `NotFoundError → 404` handler registered in `build_app`, mirroring the existing `DuplicateKeyError` handler.

## Changes

- `app/exceptions.py` — new `not_found_error_handler` returning `404 {"detail": "Not found"}`.
- `app/application.py` — register `NotFoundError: exceptions.not_found_error_handler`.
- `app/repositories.py` — `fetch_with_cards` tightens to `-> models.Deck`, using `get_one` (raises on miss) instead of `get_one_or_none`.
- `app/api/decks.py` — `get_deck` / `update_deck` / `get_card` drop all 404 code; `get_card` uses `get_one`. Removed now-unused imports (`HTTPException`, `status_codes`, `NotFoundError`).

No handler mentions 404 any more — the not-found decision lives where the data access happens, mapped to a response in one place.

## Decisions (from design grilling)

- Seam = advanced-alchemy `NotFoundError` (the signal the repository already emits; matches the `DuplicateKeyError` convention).
- Reads use the raising variant; the raise is pushed behind `fetch_with_cards`.
- 404 body is generic `{"detail": "Not found"}` — advanced-alchemy's `NotFoundError.detail` is empty and no test asserts the message.

## Verification

- `just test` → 19 passed, 100% coverage
- `ruff format` / `ruff check` / `ty check` clean
- Net **−** lines (deletes more than it adds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)