### PR TITLE
refactor: extract test-transaction seam from production session

### DIFF
--- a/app/resources/db.py
+++ b/app/resources/db.py
@@ -25,16 +25,16 @@ async def close_sa_engine(engine: sa.AsyncEngine) -> None:
     await engine.dispose()
 
 
-class CustomAsyncSession(sa.AsyncSession):
-    async def close(self) -> None:
-        if isinstance(self.bind, sa.AsyncConnection):
-            return self.expunge_all()
-
-        return await super().close()
-
-
 def create_session(engine: sa.AsyncEngine) -> sa.AsyncSession:
-    return CustomAsyncSession(engine, expire_on_commit=False, autoflush=False)
+    # join_transaction_mode is inert in production (the session binds to an engine); when tests bind
+    # the session to a connection already in a transaction, it makes the session own a savepoint so
+    # the outer transaction survives commits and the per-test rollback stays clean.
+    return sa.AsyncSession(
+        engine,
+        expire_on_commit=False,
+        autoflush=False,
+        join_transaction_mode="create_savepoint",
+    )
 
 
 async def close_session(session: sa.AsyncSession) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,15 @@ async def db_session(di_container: modern_di.Container) -> typing.AsyncIterator[
     engine = create_sa_engine()
     connection = await engine.connect()
     transaction = await connection.begin()
-    await connection.begin_nested()
     di_container.override(ioc.Dependencies.database_engine, connection)
 
     try:
-        yield AsyncSession(connection, expire_on_commit=False, autoflush=False)
+        yield AsyncSession(
+            connection,
+            expire_on_commit=False,
+            autoflush=False,
+            join_transaction_mode="create_savepoint",
+        )
     finally:
         if connection.in_transaction():
             await transaction.rollback()


### PR DESCRIPTION
## What

`CustomAsyncSession` existed for one reason: so the per-test rollback worked. Its `close()` became a no-op (`expunge_all`) when the session was bound to a connection — i.e. a **test concern leaking into the production data-access module** (`app/resources/db.py`).

This removes it. Test-transaction ownership now lives where it belongs (the `db_session` fixture), using SQLAlchemy 2.0's native `join_transaction_mode="create_savepoint"`.

## How

With `create_savepoint`, each session owns its **own** savepoint. Advanced-alchemy's `auto_commit` releases that savepoint while the fixture's outer real transaction survives and is rolled back at the end of each test. This obsoletes both the `close()` override and the `begin_nested()` that the old `conditional_savepoint` default required.

The kwarg is **inert in production**: it only takes effect when the session is bound to a connection already in a transaction, which production never does (it binds to an engine).

## Changes

- `app/resources/db.py` — delete `CustomAsyncSession`; `create_session` returns a plain `AsyncSession(..., join_transaction_mode="create_savepoint")` (commented to explain the prod-inert rationale).
- `tests/conftest.py` — drop `connection.begin_nested()`; the fixture's polyfactory session takes the same mode.

Production session has no test branch any more; per-request-session fidelity is preserved (the fixture still overrides `database_engine` → connection, so each request builds its own session).

## Verification

- `just test` → 19 passed, 100% coverage. Isolation is exercised: `test_get_decks_empty` / `test_get_cards_empty` assert emptiness and would fail if a prior test's writes leaked.
- `ruff format` / `ruff check` / `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)