### PR TITLE
refactor: deepen ORM→HTTP serialization behind a Collection seam

### DIFF
--- a/app/api/decks.py
+++ b/app/api/decks.py
@@ -2,7 +2,6 @@ import typing
 
 import litestar
 from litestar.params import FromPath  # noqa: TC002
-from litestar.plugins.pydantic import PydanticDTO
 
 from app import models, schemas
 from app.repositories import CardsRepository, DecksRepository  # noqa: TC001
@@ -11,7 +10,7 @@ from app.repositories import CardsRepository, DecksRepository  # noqa: TC001
 @litestar.get("/decks/")
 async def list_decks(decks_repository: DecksRepository) -> schemas.Decks:
     objects = await decks_repository.get_many()
-    return schemas.Decks(items=objects)  # ty: ignore[invalid-argument-type]
+    return schemas.Decks.from_models(objects)
 
 
 @litestar.get("/decks/{deck_id:int}/")
@@ -39,10 +38,10 @@ async def create_deck(data: schemas.DeckCreate, decks_repository: DecksRepositor
 @litestar.get("/decks/{deck_id:int}/cards/")
 async def list_cards(deck_id: FromPath[int], cards_repository: CardsRepository) -> schemas.Cards:
     objects = await cards_repository.list_for_deck(deck_id)
-    return schemas.Cards(items=objects)  # ty: ignore[invalid-argument-type]
+    return schemas.Cards.from_models(objects)
 
 
-@litestar.get("/cards/{card_id:int}/", return_dto=PydanticDTO[schemas.Card])
+@litestar.get("/cards/{card_id:int}/")
 async def get_card(card_id: FromPath[int], cards_repository: CardsRepository) -> schemas.Card:
     instance = await cards_repository.get_one(models.Card.id == card_id)
     return schemas.Card.model_validate(instance)
@@ -53,7 +52,7 @@ async def create_cards(
     deck_id: FromPath[int], data: list[schemas.CardCreate], cards_repository: CardsRepository
 ) -> schemas.Cards:
     objects = await cards_repository.add_cards(deck_id, data)
-    return schemas.Cards(items=objects)  # ty: ignore[invalid-argument-type]
+    return schemas.Cards.from_models(objects)
 
 
 @litestar.put("/decks/{deck_id:int}/cards/")
@@ -61,7 +60,7 @@ async def update_cards(
     deck_id: FromPath[int], data: list[schemas.Card], cards_repository: CardsRepository
 ) -> schemas.Cards:
     objects = await cards_repository.upsert_cards(deck_id, data)
-    return schemas.Cards(items=objects)  # ty: ignore[invalid-argument-type]
+    return schemas.Cards.from_models(objects)
 
 
 ROUTER: typing.Final = litestar.Router(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,9 +1,23 @@
+from typing import TYPE_CHECKING, Self
+
 import pydantic
 from pydantic import BaseModel, PositiveInt
 
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
 class Base(BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
+
+
+class Collection[T: Base](Base):
+    items: list[T]
+
+    @classmethod
+    def from_models(cls, objects: Iterable[object]) -> Self:
+        return cls.model_validate({"items": list(objects)})
 
 
 class CardBase(Base):
@@ -21,8 +35,8 @@ class Card(CardBase):
     deck_id: PositiveInt | None = None
 
 
-class Cards(Base):
-    items: list[Card]
+class Cards(Collection[Card]):
+    pass
 
 
 class DeckBase(Base):
@@ -39,5 +53,5 @@ class Deck(DeckBase):
     cards: list[Card] | None
 
 
-class Decks(Base):
-    items: list[Deck]
+class Decks(Collection[Deck]):
+    pass


### PR DESCRIPTION
## Problem

The persistence→HTTP serialization seam was shallow and leaked. Every list handler built its response envelope from raw ORM rows:

```python
return schemas.Decks(items=objects)  # ty: ignore[invalid-argument-type]
```

— each of the four carrying a `ty: ignore` for the `Sequence[Model]` → `list[Schema]` static mismatch. `get_card` separately carried a stray `return_dto=PydanticDTO[schemas.Card]` on top of a manual `model_validate`.

## Change

Introduce a deep `Collection[T]` seam in `app/schemas.py`:

```python
class Collection[T: Base](Base):
    items: list[T]

    @classmethod
    def from_models(cls, objects: Iterable[object]) -> Self:
        return cls.model_validate({"items": list(objects)})

class Cards(Collection[Card]): pass
class Decks(Collection[Deck]): pass
```

The ORM→schema coercion now happens once, behind a small interface. Routing through `model_validate` (param typed `Any`) absorbs the coercion cleanly, so **all four `ty: ignore[invalid-argument-type]` suppressions are removed**. List handlers call `schemas.Xs.from_models(objects)`; `get_card` drops its redundant DTO and now returns through its schema like every other handler.

`Decks`/`Cards` stay as named subclasses, so OpenAPI schema names are unchanged.

## Contract & tests

- **Wire contract unchanged** — `{items: [...]}`, no audit timestamps, same schema names.
- Single-object handlers unchanged (`schemas.X.model_validate(instance)` was already typed).
- The seam is exercised by every list-endpoint test; existing HTTP tests are the test surface. **19 passed, 100% coverage held.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)