### PR TITLE
refactor: split the Deck response contract from its detail view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Python is 3.14, dependencies managed by `uv`. The API is exposed on `:8000`.
 ## Conventions
 
 - Routes live in `app/api/`, registered into a single `ROUTER` (prefix `/api`) referenced from `application.py`. Add a new resource by creating `app/api/<name>.py`, defining handlers + a `Router`, and adding it to `application.build_app`.
-- Pydantic schemas in `app/schemas.py` use `from_attributes=True` (via `Base`) so they validate directly from ORM instances (`schemas.X.model_validate(orm_instance)`).
+- Pydantic schemas in `app/schemas.py` use `from_attributes=True` (via `Base`) so they validate directly from ORM instances (`schemas.X.model_validate(orm_instance)`). Collection responses go through `Collection[T].from_models(...)` (e.g. `schemas.Decks`, `schemas.Cards`).
+- Deck responses are deliberately two-shaped: `list_decks`/`create_deck`/`update_deck` return the light `schemas.Deck` (no `cards`), while `get_deck` returns `schemas.DeckWithCards`. The split mirrors loading — lists use `noload` (no cards query), detail uses `selectinload` via `fetch_with_cards` — so the type states exactly what each endpoint loads.
 - Domain exceptions: register handlers in `application.build_app`'s `exception_handlers` dict (see `DuplicateKeyError` → `exceptions.duplicate_key_error_handler`). For per-handler 404s the code raises `litestar.exceptions.HTTPException` directly.
 - `ruff` is configured with `select = ["ALL"]` and a line length of 120 — expect strict lint. Type-check with `ty`; use `# ty: ignore[<rule>]` for suppressions (already used for `invalid-argument-type` around `LifespanManager` / `ASGITransport` / DTO list construction).

--- a/app/api/decks.py
+++ b/app/api/decks.py
@@ -14,9 +14,9 @@ async def list_decks(decks_repository: DecksRepository) -> schemas.Decks:
 
 
 @litestar.get("/decks/{deck_id:int}/")
-async def get_deck(deck_id: FromPath[int], decks_repository: DecksRepository) -> schemas.Deck:
+async def get_deck(deck_id: FromPath[int], decks_repository: DecksRepository) -> schemas.DeckWithCards:
     instance = await decks_repository.fetch_with_cards(deck_id)
-    return schemas.Deck.model_validate(instance)
+    return schemas.DeckWithCards.model_validate(instance)
 
 
 @litestar.put("/decks/{deck_id:int}/")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -49,8 +49,15 @@ class DeckCreate(DeckBase):
 
 
 class Deck(DeckBase):
+    """Light deck view for lists and writes; cards are not loaded."""
+
     id: PositiveInt
-    cards: list[Card] | None
+
+
+class DeckWithCards(Deck):
+    """Deck detail view; cards are eager-loaded (selectinload) and always present."""
+
+    cards: list[Card]
 
 
 class Decks(Collection[Deck]):


### PR DESCRIPTION
## Problem

One `Deck` schema served two endpoints with different card-loading strategies, leaking the difference into the type:

```python
class Deck(DeckBase):
    id: PositiveInt
    cards: list[Card] | None
```

- `get_deck` → `fetch_with_cards` (`selectinload`) → cards populated.
- `list_decks` / `create_deck` / `update_deck` → relationship is `lazy="noload"`, so `.cards` returns `[]` **without loading**.

So `list_decks` reported `cards: []` for *every* deck even when the deck has cards — the list contract was lying. The `| None` was also dead: `noload` yields `[]`, never `None`.

## Change

Split the one schema into two:

```python
class Deck(DeckBase):
    """Light deck view for lists and writes; cards are not loaded."""
    id: PositiveInt

class DeckWithCards(Deck):
    """Deck detail view; cards are eager-loaded (selectinload) and always present."""
    cards: list[Card]
```

- `get_deck` → `DeckWithCards` (cards always present, non-optional)
- `list_decks` → `Decks` (`Collection[Deck]`), `create_deck` / `update_deck` → `Deck`

Each endpoint's return type now states exactly what it loads. The dead `| None` is gone. The two-shape convention is documented in **CLAUDE.md** (Conventions) and in docstrings on the schemas.

## Contract change ⚠️

Intentional: the `cards` key **disappears** from `list` / `create` / `update` responses (they never loaded cards anyway). `get_deck` is unchanged. Any client reading `cards` off a list response is affected.

## Tests

`test_get_one_deck` locks `DeckWithCards` (asserts `cards`); list/create/update tests never asserted `cards`, so they stay green. **19 passed, 100% coverage.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)