### PR TITLE
fix: read instance attributes in api_bootstrapper_config

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -37,18 +37,18 @@ class Settings(pydantic_settings.BaseSettings):
     @property
     def api_bootstrapper_config(self) -> LitestarConfig:
         return LitestarConfig(
-            service_name=settings.service_name,
-            service_version=settings.service_version,
-            service_environment=settings.service_environment,
-            service_debug=settings.service_debug,
-            opentelemetry_endpoint=settings.opentelemetry_endpoint,
-            sentry_dsn=settings.sentry_dsn,
-            cors_allowed_origins=settings.cors_allowed_origins,
-            cors_allowed_methods=settings.cors_allowed_methods,
-            cors_allowed_headers=settings.cors_allowed_headers,
-            cors_exposed_headers=settings.cors_exposed_headers,
-            logging_buffer_capacity=settings.logging_buffer_capacity,
-            swagger_offline_docs=settings.swagger_offline_docs,
+            service_name=self.service_name,
+            service_version=self.service_version,
+            service_environment=self.service_environment,
+            service_debug=self.service_debug,
+            opentelemetry_endpoint=self.opentelemetry_endpoint,
+            sentry_dsn=self.sentry_dsn,
+            cors_allowed_origins=self.cors_allowed_origins,
+            cors_allowed_methods=self.cors_allowed_methods,
+            cors_allowed_headers=self.cors_allowed_headers,
+            cors_exposed_headers=self.cors_exposed_headers,
+            logging_buffer_capacity=self.logging_buffer_capacity,
+            swagger_offline_docs=self.swagger_offline_docs,
         )
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,10 @@
+from app.settings import Settings
+
+
+def test_api_bootstrapper_config_reads_instance_not_global() -> None:
+    custom = Settings(service_name="custom-service", service_version="9.9.9")
+
+    config = custom.api_bootstrapper_config
+
+    assert config.service_name == "custom-service"
+    assert config.service_version == "9.9.9"


### PR DESCRIPTION
## Bug

`Settings.api_bootstrapper_config` built its `LitestarConfig` from the module-global `settings` singleton instead of `self`:

```python
@property
def api_bootstrapper_config(self) -> LitestarConfig:
    return LitestarConfig(
        service_name=settings.service_name,   # ← global, not self
        ...
    )
```

So any `Settings` instance other than the singleton — or any access during the singleton's own construction — silently produced the singleton's values rather than its own.

## Fix

Every field now reads `self.*`.

## Test (TDD — failing first)

Added `tests/test_settings.py`, which constructs a `Settings(service_name="custom-service", service_version="9.9.9")` and asserts `api_bootstrapper_config` reflects the instance.

- **Before the fix (RED):** `assert 'Litestar template' == 'custom-service'` — fails, proving the global leak.
- **After the fix (GREEN):** passes.

**20 passed, 100% coverage.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)