### PR TITLE
test: lock that the deck list omits cards

### DIFF
--- a/tests/test_decks.py
+++ b/tests/test_decks.py
@@ -35,6 +35,16 @@ async def test_get_decks(client: AsyncClient) -> None:
         assert v == getattr(deck, k)
 
 
+async def test_list_decks_omits_cards(client: AsyncClient) -> None:
+    deck = await factories.DeckModelFactory.create_async()
+    await factories.CardModelFactory.create_async(deck_id=deck.id)
+
+    response = await client.get("/api/decks/")
+    assert response.status_code == status_codes.HTTP_200_OK
+    item = response.json()["items"][0]
+    assert "cards" not in item
+
+
 async def test_get_one_deck(client: AsyncClient) -> None:
     deck = await factories.DeckModelFactory.create_async()
     card = await factories.CardModelFactory.create_async(deck_id=deck.id)


### PR DESCRIPTION
## Why

PR #30 split the Deck response contract — light `Deck` for `list`/`create`/`update`, `DeckWithCards` for `get_deck` — but no test asserted that `cards` is *absent* from list responses. The existing tests passed under both the old and new schema, so the contract wasn't pinned.

## What

`test_list_decks_omits_cards` creates a deck **with** a card, then asserts the list item has no `cards` key:

```python
async def test_list_decks_omits_cards(client: AsyncClient) -> None:
    deck = await factories.DeckModelFactory.create_async()
    await factories.CardModelFactory.create_async(deck_id=deck.id)

    response = await client.get("/api/decks/")
    item = response.json()["items"][0]
    assert "cards" not in item
```

Under the old single-schema design this would have **failed** — `list_decks` returned the misleading `cards: []` even for decks with cards (the `noload` lie #30 removed). So the test locks the fix and would catch a regression that re-added `cards` to the light contract. `test_get_one_deck` already locks the other half (detail includes cards).

**21 passed, 100% coverage.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)