### PR TITLE
fix: correct CORS allowed-methods/headers defaults

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -24,8 +24,8 @@ class Settings(pydantic_settings.BaseSettings):
     swagger_offline_docs: bool = True
 
     cors_allowed_origins: list[str] = ["http://localhost:5173"]
-    cors_allowed_methods: list[str] = [""]
-    cors_allowed_headers: list[str] = [""]
+    cors_allowed_methods: list[str] = ["*"]
+    cors_allowed_headers: list[str] = ["*"]
     cors_exposed_headers: list[str] = []
 
     request_max_body_size: int = 1024 * 1024  # 1MB limit

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,19 @@
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+
+async def test_cors_preflight_allows_write_methods(client: AsyncClient) -> None:
+    response = await client.options(
+        "/api/decks/",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    allow_methods = response.headers.get("access-control-allow-methods", "")
+    assert "POST" in allow_methods
+    assert "PUT" in allow_methods


### PR DESCRIPTION
## Bug

`settings.py` defaulted the CORS lists to a single empty string:

```python
cors_allowed_methods: list[str] = [""]
cors_allowed_headers: list[str] = [""]
```

`[""]` is neither "allow all" (`["*"]`) nor empty (`[]`). It flows through `lite-bootstrap` into Litestar's `CORSConfig`, which on preflight produces:

```
Access-Control-Allow-Methods: ''                                          ← empty
Access-Control-Allow-Headers: ', Accept, Accept-Language, Content-Language, Content-Type'   ← stray leading comma
```

`is_allow_all_methods` is `"*" in [""]` → `False`, but the list is non-empty, so Litestar emits `", ".join({""})` → the empty string.

### Impact
A browser SPA at the configured dev origin `http://localhost:5173` doing any preflighted request — every `POST`/`PUT` write endpoint with `Content-Type: application/json` — receives an **empty** `Access-Control-Allow-Methods` and the browser **blocks the request**. The template's default CORS was broken for the exact origin it ships with. (`allowed_headers` was functionally OK — `Content-Type` is covered by Litestar's defaults — but emitted a stray empty token.)

## Fix

```python
cors_allowed_methods: list[str] = ["*"]   # → DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT
cors_allowed_headers: list[str] = ["*"]   # → allow-all, no stray token
```

Permissive dev defaults; tighten via env in prod.

## Test (TDD — failing first)

`tests/test_cors.py` sends a preflight `OPTIONS /api/decks/` (`Origin: localhost:5173`, `Access-Control-Request-Method: POST`) through the `client` fixture and asserts `POST`/`PUT` appear in `Access-Control-Allow-Methods` — exercising the real settings → bootstrap → middleware wiring.

- **Before (RED):** allow-methods is `''` → `POST` absent → fails.
- **After (GREEN):** full method set → passes.

**22 passed, 100% coverage.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)