### PR TITLE
docs: add brand logo banner to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,10 @@
-# litestar-sqlalchemy-template
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)"  srcset="https://raw.githubusercontent.com/modern-python/.github/main/brand/projects/litestar-sqlalchemy-template/lockup-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/modern-python/.github/main/brand/projects/litestar-sqlalchemy-template/lockup-light.svg">
+    <img alt="litestar-sqlalchemy-template" src="https://raw.githubusercontent.com/modern-python/.github/main/brand/projects/litestar-sqlalchemy-template/lockup.png" width="420">
+  </picture>
+</p>
 
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen.svg)](https://github.com/modern-python/litestar-sqlalchemy-template/actions/workflows/main.yml)
 [![CI](https://github.com/modern-python/litestar-sqlalchemy-template/actions/workflows/main.yml/badge.svg)](https://github.com/modern-python/litestar-sqlalchemy-template/actions/workflows/main.yml)


### PR DESCRIPTION
Add the modern-python brand logo banner as the leading element of readme.md, replacing the plain H1 heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)